### PR TITLE
Set default port value to null

### DIFF
--- a/classes/Database/MySQLi.php
+++ b/classes/Database/MySQLi.php
@@ -40,7 +40,7 @@ class Database_MySQLi extends Database {
 			'hostname'   => '',
 			'username'   => '',
 			'password'   => '',
-			'port'       => '',
+			'port'       => null,
 			'socket'     => ''
 		));
 


### PR DESCRIPTION
In PHP 5.5.9 passing the port as string raises a type mismatch error.
